### PR TITLE
Make sure agent is actually connected

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,4 @@
-package: github.com/shazam/jenkins-nodes-auto-scaler
+package: github.com/lucanaldini/jenkins-nodes-auto-scaler
 
 import:
 

--- a/main.go
+++ b/main.go
@@ -377,7 +377,8 @@ func launchNodeAgent(buildBox string) bool {
 				return
 			default:
 				if isAgentConnected(buildBox) {
-					online <- true
+					time.Sleep(10 * time.Second)
+					online <- isAgentConnected(buildBox)
 					return
 				}
 

--- a/main.go
+++ b/main.go
@@ -378,8 +378,12 @@ func launchNodeAgent(buildBox string) bool {
 			default:
 				if isAgentConnected(buildBox) {
 					time.Sleep(10 * time.Second)
-					online <- isAgentConnected(buildBox)
-					return
+					if stillConnected := isAgentConnected(buildBox); !stillConnected {
+						log.Printf("Agent appeared to be connected for %s, but it disconnected shortly after\n", buildBox)
+					} else {
+						online <- true
+						return
+					}
 				}
 
 				if counter%10 == 0 {


### PR DESCRIPTION
Sometimes the agent confirms to have connected to the node, but few seconds after disconnects (https://issues.jenkins-ci.org/browse/JENKINS-48538 is an example).
This PR is to check that the agent is still connected after a few seconds it announced to be, before marking the node as available to accept jobs.