### PR TITLE
Fix deadlock when agent connects right at the end of the timeout

### DIFF
--- a/main.go
+++ b/main.go
@@ -367,7 +367,7 @@ func toggleNodeStatus(buildBox string, message string) error {
 func launchNodeAgent(buildBox string) bool {
 	log.Printf("Agent was launched for %s, waiting for it to come online\n", buildBox)
 
-	quit := make(chan bool)
+	quit := make(chan bool, 1)
 	online := make(chan bool, 1)
 	go func() {
 		counter := 0
@@ -402,9 +402,9 @@ func launchNodeAgent(buildBox string) bool {
 	select {
 	case <-online:
 	case <-time.After(time.Second * 120):
-		log.Printf("Unable to launch the agent for %s successfully, shutting down", buildBox)
 		quit <- true
 		agentLaunched = false
+		log.Printf("Unable to launch the agent for %s successfully, shutting down", buildBox)
 		stopCloudBox(buildBox)
 	}
 


### PR DESCRIPTION
The process would get stuck on writing to the quit channel in case the node gets connected with an agent right at the end of the allowed time.
Also added timeout on fetching compute engine status in case the vm does not change its status.